### PR TITLE
Bug fix: "width is null or not an object" from IE8 occasionally

### DIFF
--- a/jquery.backgroundSize.js
+++ b/jquery.backgroundSize.js
@@ -178,8 +178,12 @@ $.refreshBackground = function( elem ) {
 		imgDim = $.data( elem, "bgsImgDim" ),
 		$img = $( $.data( elem, "bgsImg" ) ),
 		pos = $.data( elem, "bgsPos" ),
-		prevConstrain = $.data( elem, "bgsConstrain" ),
-		currConstrain,
+		prevConstrain = $.data( elem, "bgsConstrain" );
+
+	if (!elemDim || !imgDim)
+		return;
+
+	var currConstrain,
 		elemRatio = elemDim.width / elemDim.height,
 		imgRatio = imgDim.width / imgDim.height,
 		delta;


### PR DESCRIPTION
Bug fix: "width is null or not an object" from IE8 occasionally.
![backgroundsize_bug](https://f.cloud.github.com/assets/1812260/700249/bb64367c-dd3e-11e2-8941-88e8731319df.png)

Additional:
Not properly working with jquery 1.9.1 + ie8 (undefined is null or not an object)
![1 9 1_bug](https://f.cloud.github.com/assets/1812260/700250/bb6980dc-dd3e-11e2-8ec0-839f5c509010.png)

Works well with jquery 1.10.1 + ie8
